### PR TITLE
ssl removed from 'globo.com' link

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <div class="container">
 
       <div class="hero-unit header">
-        <a class="glb-logo" href="https://globo.com/"></a>
+        <a class="glb-logo" href="http://globo.com/"></a>
         <div class="btns">
 	        <a class="btn btn-primary btn-large" href="https://github.com/globocom/">globo.com no github</a>
 	        <a class="btn btn-primary btn-large" href="http://talentos.globo.com">quer trabalhar conosco?</a>


### PR DESCRIPTION
![screenshot from 2017-08-28 15-19-55](https://user-images.githubusercontent.com/1672089/29787224-886613ac-8c04-11e7-876f-93592cf2e2cf.png)

Fixes a fail redirect (connection refused). There's no SSL certificate in this domain.