### PR TITLE
Improve Makefile to show tasks when run "make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ setup:
 ## starts development server
 start:
 	yarn develop
-# builds static files to production
+
+## builds static files to production
 build:
 	yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ setup:
 ## starts development server
 start:
 	yarn develop
-
+# builds static files to production
 build:
 	yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,38 @@
-.PHONY: setup start build deploy
+.SILENT:
+.DEFAULT_GOAL=help
 
+COLOR_RESET = \033[0m
+COLOR_GREEN = \033[32m
+COLOR_YELLOW = \033[33m
+
+PROJECT_NAME = `basename $(PWD)`
+
+## prints this help
+help:
+	printf "${COLOR_YELLOW}\n${PROJECT_NAME}\n\n${COLOR_RESET}"
+	awk '/^[a-zA-Z\-\_0-9\.%]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "${COLOR_GREEN}$$ make %s${COLOR_RESET} %s\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	printf "\n"
+
+## installs project dependencies
 setup:
 	yarn install
 
+## starts development server
 start:
 	yarn develop
 
 build:
 	yarn build
 
+## deploys the app
 deploy: build
 	tsuru app-deploy public -a opensource-web
 


### PR DESCRIPTION
I think it's better run `make` and it shows all avaliable tasks, like `tsuru` does.

So, when you type `make` it will show tasks like this:

![screen shot 2018-10-22 at 09 38 05](https://user-images.githubusercontent.com/354110/47294165-a0173200-d5e2-11e8-9f1e-30ce149a4e8f.png)

Feel free to change and add descriptions of tasks.