### PR TITLE
Update HacktoberFestProgress.js

### DIFF
--- a/src/components/HacktoberFestCall/HacktoberFestProgress.js
+++ b/src/components/HacktoberFestCall/HacktoberFestProgress.js
@@ -162,7 +162,6 @@ function HacktoberFestProgress({ user }) {
               label="E-mail"
               type="email"
               placeholder="voce@example.com"
-              errorText="Oieee"
             />
             <TextInput label="Estado" type="text" placeholder="Ex.: RJ" />
             <TextInput


### PR DESCRIPTION
Retirada a linha 165, que causa o bug no campo de e-mail do formulário de solicitação da camisa HACKTOBERFEST 2019. Melhor explicado na Issue #47  .